### PR TITLE
End game on final letter instead of on space

### DIFF
--- a/src/component/Game.tsx
+++ b/src/component/Game.tsx
@@ -10,7 +10,22 @@ export const Game = () => {
   const [start, setStart] = useState<boolean>(false);
   const [incorrectLetters, setIncorrectLetters] = useState<number>(0);
 
-  const endGame = () => (currentWordIndex < words.length ? false : true);
+  const endGame = () => {
+    if (finalLetter()) {
+      setCurrentWordIndex(currentWordIndex + 1);
+      return true;
+    } else {
+      return currentWordIndex < words.length ? false : true;
+    }
+  };
+  const finalLetter = () => {
+    if (
+      currentWordIndex === words.length - 1 &&
+      currentInput === words[words.length - 1]
+    ) {
+      return true;
+    }
+  };
 
   const getCurrentWordSubstring = () => {
     if (!endGame()) {

--- a/src/component/Game.tsx
+++ b/src/component/Game.tsx
@@ -11,14 +11,15 @@ export const Game = () => {
   const [incorrectLetters, setIncorrectLetters] = useState<number>(0);
 
   const endGame = () => {
-    if (finalLetter()) {
+    if (onFinalLetter()) {
       setCurrentWordIndex(currentWordIndex + 1);
       return true;
-    } else {
-      return currentWordIndex < words.length ? false : true;
     }
+
+    return currentWordIndex < words.length ? false : true;
   };
-  const finalLetter = () => {
+
+  const onFinalLetter = () => {
     if (
       currentWordIndex === words.length - 1 &&
       currentInput === words[words.length - 1]

--- a/src/component/__tests__/Game.test.tsx
+++ b/src/component/__tests__/Game.test.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { Game } from "../Game";
+import { mount, configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+configure({ adapter: new Adapter() });
+
+describe("Game", () => {
+  const GameComponent = mount(<Game />);
+  const BoardComponent = GameComponent.find("Board");
+
+  it("renders the Board component", () => {
+    expect(BoardComponent.exists()).toBe(true);
+  });
+
+  it("sets currentWordSubstring as expected", () => {
+    expect(BoardComponent.prop("currentWordSubstring")).toBe("");
+  });
+});


### PR DESCRIPTION
The user no longer needs to press a space to end the game. This is
an intuitive way for the game to end. to justify what's happening here,
we figure out that the last letter has been typed correctly so we need
to advance the game forward by one word causing the game to render in
the end game state, causing the statistics to appear and the Race
component to render at the 'finish line'.

Normally this end game state would be triggered by pressing space on
the final word, we are basically breaking into the end game state before
that happens.